### PR TITLE
Add PostCSS@5.2 support

### DIFF
--- a/lib/less-parser.js
+++ b/lib/less-parser.js
@@ -137,29 +137,35 @@ export default class LessParser extends Parser {
     }
 
     /* eslint-disable max-statements, complexity */
-    word () {
+    other () {
         let end = false;
         let colon = false;
         let bracket = null;
-        let brackets = 0;
+        const brackets = [];
         const start = this.pos;
+        
+        // we need pass "()" as spaces
+        // However we can override method Parser.loop, but it seems less maintainable
+        if (this.tokens[start][0] === 'brackets') {
+            this.spaces += this.tokens[start][1];
+            return;
+        }
         const isMixin = isMixinToken(this.tokens[start]);
         const isExtendRule = Boolean(findExtendRule(this.tokens, start));
         const params = [];
 
         this.pos += 1;
-
         while (this.pos < this.tokens.length) {
             const token = this.tokens[this.pos];
             const type = token[0];
 
-            if (type === '(') {
+            if (type === '(' || type === '[') {
                 if (!bracket) {
                     bracket = token;
                 }
 
-                brackets += 1;
-            } else if (brackets === 0) {
+                brackets.push(type === '(' ? ')' : ']');
+            } else if (brackets.length === 0) {
                 if (type === ';') {
                     const foundEndOfRule = this.processEndOfRule({
                         start,
@@ -184,14 +190,14 @@ export default class LessParser extends Parser {
                 } else if (type === ':') {
                     colon = true;
                 }
-            } else if (type === ')') {
-                brackets -= 1;
-                if (brackets === 0) {
+            } else if (type === brackets[brackets.length - 1]) {
+                brackets.pop();
+                if (brackets.length === 0) {
                     bracket = null;
                 }
             }
 
-            if (brackets || type === 'brackets' || params[0]) {
+            if (brackets.length > 0 || type === 'brackets' || params[0]) {
                 params.push(token);
             }
 
@@ -203,7 +209,7 @@ export default class LessParser extends Parser {
             end = true;
         }
 
-        if (brackets > 0) {
+        if (brackets.length > 0) {
             this.unclosedBracket(bracket);
         }
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2376,9 +2376,9 @@
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz"
     },
     "postcss": {
-      "version": "5.0.21",
-      "from": "postcss@5.0.21",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.0.21.tgz"
+      "version": "5.2.16",
+      "from": "postcss@5.2.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz"
     },
     "postcss-parser-tests": {
       "version": "5.0.6",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "prepublish": "./node_modules/.bin/gulp dist"
   },
   "dependencies": {
-    "postcss": "^5.0.21"
+    "postcss": "^5.2.16"
   },
   "devDependencies": {
     "babel-core": "^6.7.2",


### PR DESCRIPTION
With PostCSS@5.2 release ( https://github.com/postcss/postcss/commit/dacd3921a11ade9b5e19d44908da6820430cf696 ) method Parser.word was renamed to Parser.other. Also method Parser.loop was changed. 

To support PostCSS@5.2 we need to rename word method and change its signature

However we can override method Parser.loop in LessParser, but it seems less maintainable.

https://github.com/webschik/postcss-less/issues/60