### PR TITLE
Fix semicolons with Mixin, Extend Rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,21 +1,15 @@
-# EditorConfig helps developers define and maintain consistent
-# coding styles between different editors and IDEs
-# http://editorconfig.org
-
 root = true
 
 [*]
-# Don't modify any files by default (opt-in below)
-trim_trailing_whitespace = false
-insert_final_newline = false
-
-[{lib/,test/,./*}]
-# Change these settings to your own preference
 indent_style = space
-indent_size = 2
-
-# We recommend you to keep these unchanged
+indent_size = 4
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.{json,yml}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/README.md
+++ b/README.md
@@ -57,6 +57,74 @@ If you need to support inline comments, please use a [custom PostCSSLess stringi
 
 [PostCSS Rule Node](https://github.com/postcss/postcss/blob/master/docs/api.md#rule-node)
 
+### rule.extend
+
+Determines whether or not a rule is [nested](http://lesscss.org/features/#extend-feature-extend-inside-ruleset).
+
+```js
+import postCssLess from 'postcss-less';
+const less = `
+    .class2 {
+        &:extend(.class1);
+    }
+`;
+const root = postCssLess.parse(less);
+
+root.first.nodes[0].extend // => true
+```
+
+### rule.important
+
+Determines whether or not a rule is marked as [important](http://lesscss.org/features/#mixins-feature-the-important-keyword).
+
+```js
+import postCssLess from 'postcss-less';
+const less = `
+    .class2 {
+        &:extend(.class1);
+    }
+`;
+const root = postCssLess.parse(less);
+
+root.first.nodes[0].extend // => true
+```
+
+### rule.mixin
+
+Determines whether or not a rule is a [mixin](http://lesscss.org/features/#mixins-feature).
+
+```js
+import postCssLess from 'postcss-less';
+const less = `
+    .class2 {
+        .mixin-name;
+    }
+`;
+const root = postCssLess.parse(less);
+
+root.first.nodes[0].mixin // => true
+```
+
+### rule.nodes
+
+An `Array` of child nodes.
+
+**Note** that `nodes` is `undefined` for rules that don't contain declarations.
+
+```js
+import postCssLess from 'postcss-less';
+const less = `
+    .class2 {
+        &:extend(.class1);
+        .mixin-name(@param1, @param2);
+    }
+`;
+const root = postCssLess.parse(less);
+
+root.first.nodes[0].nodes // => undefined for &:extend
+root.first.nodes[1].nodes // => undefined for mixin
+```
+
 ### rule.ruleWithoutBody
 Determines whether or not a rule has a body, or content.
 
@@ -72,42 +140,6 @@ const root = postCssLess.parse(less);
 
 root.first.nodes[0].ruleWithoutBody // => true for &:extend
 root.first.nodes[1].ruleWithoutBody // => true for calling of mixin
-```
-### rule.nodes
-
-An `Array` of child nodes.
-
-**Note** that rules without body don't have this property.
-
-```js
-import postCssLess from 'postcss-less';
-const less = `
-    .class2 {
-        &:extend(.class1);
-        .mixin-name(@param1, @param2);
-    }
-`;
-const root = postCssLess.parse(less);
-
-root.first.nodes[0].nodes // => undefined for &:extend
-root.first.nodes[1].nodes // => undefined for mixin calling
-```
-
-### rule.extendRule
-
-Determines whether or not a rule is nested (eg.
- [extended](http://lesscss.org/features/#extend-feature-extend-inside-ruleset)).
-
-```js
-import postCssLess from 'postcss-less';
-const less = `
-    .class2 {
-        &:extend(.class1);
-    }
-`;
-const root = postCssLess.parse(less);
-
-root.first.nodes[0].extendRule // => true
 ```
 
 ## Comment Node

--- a/README.md
+++ b/README.md
@@ -57,6 +57,24 @@ If you need to support inline comments, please use a [custom PostCSSLess stringi
 
 [PostCSS Rule Node](https://github.com/postcss/postcss/blob/master/docs/api.md#rule-node)
 
+### rule.empty
+
+Determines whether or not a rule contains declarations.
+
+```js
+import postCssLess from 'postcss-less';
+const less = `
+    .class2 {
+        &:extend(.class1);
+        .mixin-name(@param1, @param2);
+    }
+`;
+const root = postCssLess.parse(less);
+
+root.first.nodes[0].empty // => true for &:extend
+root.first.nodes[1].empty // => true for calling of mixin
+```
+
 ### rule.extend
 
 Determines whether or not a rule is [nested](http://lesscss.org/features/#extend-feature-extend-inside-ruleset).
@@ -123,23 +141,6 @@ const root = postCssLess.parse(less);
 
 root.first.nodes[0].nodes // => undefined for &:extend
 root.first.nodes[1].nodes // => undefined for mixin
-```
-
-### rule.ruleWithoutBody
-Determines whether or not a rule has a body, or content.
-
-```js
-import postCssLess from 'postcss-less';
-const less = `
-    .class2 {
-        &:extend(.class1);
-        .mixin-name(@param1, @param2);
-    }
-`;
-const root = postCssLess.parse(less);
-
-root.first.nodes[0].ruleWithoutBody // => true for &:extend
-root.first.nodes[1].ruleWithoutBody // => true for calling of mixin
 ```
 
 ## Comment Node

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ If you need to support inline comments, please use a [custom PostCSSLess stringi
 
 Determines whether or not a rule contains declarations.
 
+_Note: Previously `ruleWithoutBody`. This is a breaking change from v0.16.0 to v1.0.0._
+
 ```js
 import postCssLess from 'postcss-less';
 const less = `
@@ -79,6 +81,8 @@ root.first.nodes[1].empty // => true for calling of mixin
 
 Determines whether or not a rule is [nested](http://lesscss.org/features/#extend-feature-extend-inside-ruleset).
 
+_Note: Previously `extendRule`. This is a breaking change from v0.16.0 to v1.0.0._
+
 ```js
 import postCssLess from 'postcss-less';
 const less = `
@@ -95,16 +99,19 @@ root.first.nodes[0].extend // => true
 
 Determines whether or not a rule is marked as [important](http://lesscss.org/features/#mixins-feature-the-important-keyword).
 
+_Note: This is a breaking change from v0.16.0 to v1.0.0._
+
 ```js
 import postCssLess from 'postcss-less';
 const less = `
-    .class2 {
-        &:extend(.class1);
+    .class {
+        .mixin !important;
     }
 `;
 const root = postCssLess.parse(less);
 
-root.first.nodes[0].extend // => true
+root.first.nodes[0].important // => true
+root.first.nodes[0].selector // => '.mixin'
 ```
 
 ### rule.mixin

--- a/lib/less-parser.js
+++ b/lib/less-parser.js
@@ -184,8 +184,14 @@ export default class LessParser extends Parser {
         // remove `nodes` property from rules without body
         // eslint-disable-next-line
         delete this.current.nodes;
-        this.current.extendRule = this.current.selector.indexOf('&:extend') >= 0;
-        this.current.important = this.current.selector.indexOf('!important') >= 0;
+
+        if (options.isExtendRule) {
+            this.current.extend = true;
+        }
+
+        if (this.current.selector.indexOf('!important') >= 0) {
+            this.current.important = true;
+        }
 
         this.pos--;
 

--- a/lib/less-parser.js
+++ b/lib/less-parser.js
@@ -106,6 +106,8 @@ export default class LessParser extends Parser {
         node.raws.between = this.spacesFromEnd(tokens);
         this.raw(node, 'selector', tokens);
         this.current = node;
+
+        return node;
     }
 
     comment (token) {
@@ -144,19 +146,43 @@ export default class LessParser extends Parser {
      * @param options {{start: number, params: Array}}
      */
     createRule (options) {
-        this.rule(this.tokens.slice(options.start, this.pos + 1));
+        const node = this.rule(this.tokens.slice(options.start, this.pos + 1));
 
         /**
          * By default in PostCSS `Rule.params` is `undefined`. There are rules to save the compability with PostCSS:
          *  - Don't set empty params for Rule node.
          *  - Set params fro Rule node only if it can be a mixin or &:extend rule.
          */
-        if (options.params[0] && (options.mixin || options.isExtendRule)) {
+        if (options.params[0] && (options.mixin || options.extend)) {
             this.raw(this.current, 'params', options.params);
         }
 
-        if (options.mixin) {
-            this.current.mixin = true;
+        if (options.empty) {
+
+            if (options.extend) {
+                this.current.extend = true;
+            }
+
+            if (options.mixin) {
+                this.current.mixin = true;
+            }
+
+            /**
+             * @description Mark mixin without declarations.
+             * @type {boolean}
+             */
+            this.current.empty = true;
+
+            // eslint-disable-next-line
+            delete this.current.nodes;
+
+            if (this.current.selector.indexOf('!important') >= 0) {
+                this.current.important = true;
+            }
+
+            this.pos--;
+
+            this.end(this.tokens[this.pos]);
         }
     }
 
@@ -169,36 +195,6 @@ export default class LessParser extends Parser {
     }
 
     /**
-     * @description Create a Rule block and close it, because this mixin doesn't have a body
-     * @param options
-     */
-    ruleWithoutBody (options) {
-        this.createRule(options);
-
-        /**
-         * @description Mark mixin without body.
-         * @type {boolean}
-         */
-        this.current.ruleWithoutBody = true;
-
-        // remove `nodes` property from rules without body
-        // eslint-disable-next-line
-        delete this.current.nodes;
-
-        if (options.isExtendRule) {
-            this.current.extend = true;
-        }
-
-        if (this.current.selector.indexOf('!important') >= 0) {
-            this.current.important = true;
-        }
-
-        this.pos--;
-
-        this.end(this.tokens[this.pos]);
-    }
-
-    /**
      * @description
      * @param options
      * @returns {boolean}
@@ -206,8 +202,8 @@ export default class LessParser extends Parser {
     processEndOfRule (options) {
         const {start} = options;
 
-        if (options.isExtendRule || options.mixin) {
-            this.ruleWithoutBody(options);
+        if (options.extend || options.mixin) {
+            this.createRule(Object.assign(options, {empty: true}));
             return true;
         }
 
@@ -246,7 +242,7 @@ export default class LessParser extends Parser {
             return;
         }
         const mixin = isMixinToken(this.tokens[start]);
-        const isExtendRule = Boolean(findExtendRule(this.tokens, start));
+        const extend = Boolean(findExtendRule(this.tokens, start));
         const params = [];
 
         this.pos += 1;
@@ -267,7 +263,7 @@ export default class LessParser extends Parser {
                         params,
                         colon,
                         mixin,
-                        isExtendRule
+                        extend
                     });
 
                     if (foundEndOfRule) {
@@ -293,7 +289,7 @@ export default class LessParser extends Parser {
             }
 
             // we don't want to add params for pseudo-selectors that utilize parens (#56)
-            if ((isExtendRule || !colon) && (brackets.length > 0 || type === 'brackets' || params[0])) {
+            if ((extend || !colon) && (brackets.length > 0 || type === 'brackets' || params[0])) {
                 params.push(token);
             }
 
@@ -316,7 +312,7 @@ export default class LessParser extends Parser {
                 params,
                 colon,
                 mixin,
-                isExtendRule,
+                extend,
                 isEndOfBlock: true
             });
 

--- a/lib/less-parser.js
+++ b/lib/less-parser.js
@@ -151,8 +151,12 @@ export default class LessParser extends Parser {
          *  - Don't set empty params for Rule node.
          *  - Set params fro Rule node only if it can be a mixin or &:extend rule.
          */
-        if (options.params[0] && (options.isMixin || options.isExtendRule)) {
+        if (options.params[0] && (options.mixin || options.isExtendRule)) {
             this.raw(this.current, 'params', options.params);
+        }
+
+        if (options.mixin) {
+            this.current.mixin = true;
         }
     }
 
@@ -196,7 +200,7 @@ export default class LessParser extends Parser {
     processEndOfRule (options) {
         const {start} = options;
 
-        if (options.isExtendRule || options.isMixin) {
+        if (options.isExtendRule || options.mixin) {
             this.ruleWithoutBody(options);
             return true;
         }
@@ -235,7 +239,7 @@ export default class LessParser extends Parser {
             this.spaces += this.tokens[start][1];
             return;
         }
-        const isMixin = isMixinToken(this.tokens[start]);
+        const mixin = isMixinToken(this.tokens[start]);
         const isExtendRule = Boolean(findExtendRule(this.tokens, start));
         const params = [];
 
@@ -256,7 +260,7 @@ export default class LessParser extends Parser {
                         start,
                         params,
                         colon,
-                        isMixin,
+                        mixin,
                         isExtendRule
                     });
 
@@ -266,7 +270,7 @@ export default class LessParser extends Parser {
 
                     break;
                 } else if (type === '{') {
-                    this.createRule({start, params, isMixin});
+                    this.createRule({start, params, mixin});
                     return;
                 } else if (type === '}') {
                     this.pos -= 1;
@@ -305,7 +309,7 @@ export default class LessParser extends Parser {
                 start,
                 params,
                 colon,
-                isMixin,
+                mixin,
                 isExtendRule,
                 isEndOfBlock: true
             });

--- a/lib/less-parser.js
+++ b/lib/less-parser.js
@@ -62,44 +62,72 @@ export default class LessParser extends Parser {
      * @param options {{start: number, params: Array}}
      */
     createRule (options) {
-        this.rule(this.tokens.slice(options.start, this.pos + 1));
+
+        const semi = this.tokens[this.pos][0] === ';';
+        const end = this.pos + (options.empty && semi ? 2 : 1);
+        const tokens = this.tokens.slice(options.start, end);
+        const node = this.rule(tokens);
 
         /**
-         * By default in PostCSS `Rule.params` is `undefined`. There are rules to save the compability with PostCSS:
-         *  - Don't set empty params for Rule node.
-         *  - Set params fro Rule node only if it can be a mixin or &:extend rule.
+         * By default in PostCSS `Rule.params` is `undefined`.
+         * To preserve compability with PostCSS:
+         *  - Don't set empty params for a Rule.
+         *  - Set params for a Rule only if it can be a mixin or &:extend rule.
          */
         if (options.params[0] && (options.mixin || options.extend)) {
-            this.raw(this.current, 'params', options.params);
+            this.raw(node, 'params', options.params);
         }
 
         if (options.empty) {
+            // if it's an empty mixin or extend, it must have a semicolon
+            // (that's the only way we get to this point)
+            if (semi) {
+                node.raws.semicolon = this.semicolon = true;
+                node.selector = node.selector.replace(/;$/, '');
+            }
 
             if (options.extend) {
-                this.current.extend = true;
+                node.extend = true;
             }
 
             if (options.mixin) {
-                this.current.mixin = true;
+                node.mixin = true;
             }
 
             /**
              * @description Mark mixin without declarations.
              * @type {boolean}
              */
-            this.current.empty = true;
+            node.empty = true;
 
             // eslint-disable-next-line
             delete this.current.nodes;
 
-            if (this.current.selector.indexOf('!important') >= 0) {
-                this.current.important = true;
+            if (node.selector.indexOf('!important') >= 0) {
+                node.important = true;
+                node.selector = node.selector.replace(/\s!important/, '');
             }
 
-            this.pos--;
+            // rules don't have trailing semicolons in vanilla css, so they get
+            // added to this.spaces by the parser loop, so don't step back.
+            if (!semi) {
+                this.pos--;
+            }
 
             this.end(this.tokens[this.pos]);
         }
+    }
+
+    end (token) {
+        const node = this.current;
+
+        // if a Rule contains other Rules (mixins, extends) and those have
+        // semicolons, assert that the parent Rule has a semicolon
+        if (node.nodes && node.nodes.length && node.last.raws.semicolon && !node.last.nodes) {
+            this.semicolon = true;
+        }
+
+        super.end(token);
     }
 
     import (token) {
@@ -286,6 +314,8 @@ export default class LessParser extends Parser {
 
         this.raw(node, 'selector', tokens);
         this.current = node;
+
+        return node;
     }
 
     ruleEnd (options) {

--- a/lib/less-parser.js
+++ b/lib/less-parser.js
@@ -9,15 +9,96 @@ import lessTokenizer from './less-tokenize';
 const blockCommentEndPattern = /\*\/$/;
 
 export default class LessParser extends Parser {
-    tokenize () {
-        this.tokens = lessTokenizer(this.input);
-    }
 
     atrule (token) {
         if (token[1] === '@import') {
             this.import(token);
         } else {
             super.atrule(token);
+        }
+    }
+
+    comment (token) {
+        const node = new Comment();
+        const content = token[1];
+        const text = content.slice(2).replace(blockCommentEndPattern, '');
+
+        this.init(node, token[2], token[3]);
+        node.source.end = {
+            line: token[4],
+            column: token[5]
+        };
+
+        node.raws.content = content;
+        node.raws.begin = content[0] + content[1];
+        node.inline = token[6] === 'inline';
+        node.block = !node.inline;
+
+        if (/^\s*$/.test(text)) {
+            node.text = '';
+            node.raws.left = text;
+            node.raws.right = '';
+        } else {
+            const match = text.match(/^(\s*)([^]*[^\s])(\s*)$/);
+
+            node.text = match[2];
+
+            // Add extra spaces to generate a comment in a common style /*[space][text][space]*/
+            node.raws.left = match[1] || ' ';
+            node.raws.right = match[3] || ' ';
+        }
+    }
+
+    /**
+     * @description Create a Declaration
+     * @param options {{start: number}}
+     */
+    createDeclaration (options) {
+        this.decl(this.tokens.slice(options.start, this.pos + 1));
+    }
+
+    /**
+     * @description Create a Rule node
+     * @param options {{start: number, params: Array}}
+     */
+    createRule (options) {
+        this.rule(this.tokens.slice(options.start, this.pos + 1));
+
+        /**
+         * By default in PostCSS `Rule.params` is `undefined`. There are rules to save the compability with PostCSS:
+         *  - Don't set empty params for Rule node.
+         *  - Set params fro Rule node only if it can be a mixin or &:extend rule.
+         */
+        if (options.params[0] && (options.mixin || options.extend)) {
+            this.raw(this.current, 'params', options.params);
+        }
+
+        if (options.empty) {
+
+            if (options.extend) {
+                this.current.extend = true;
+            }
+
+            if (options.mixin) {
+                this.current.mixin = true;
+            }
+
+            /**
+             * @description Mark mixin without declarations.
+             * @type {boolean}
+             */
+            this.current.empty = true;
+
+            // eslint-disable-next-line
+            delete this.current.nodes;
+
+            if (this.current.selector.indexOf('!important') >= 0) {
+                this.current.important = true;
+            }
+
+            this.pos--;
+
+            this.end(this.tokens[this.pos]);
         }
     }
 
@@ -97,136 +178,6 @@ export default class LessParser extends Parser {
         }
     }
 
-    rule (tokens) {
-        tokens.pop();
-
-        const node = new Rule();
-
-        this.init(node, tokens[0][2], tokens[0][3]);
-        node.raws.between = this.spacesFromEnd(tokens);
-        this.raw(node, 'selector', tokens);
-        this.current = node;
-
-        return node;
-    }
-
-    comment (token) {
-        const node = new Comment();
-        const content = token[1];
-        const text = content.slice(2).replace(blockCommentEndPattern, '');
-
-        this.init(node, token[2], token[3]);
-        node.source.end = {
-            line: token[4],
-            column: token[5]
-        };
-
-        node.raws.content = content;
-        node.raws.begin = content[0] + content[1];
-        node.inline = token[6] === 'inline';
-        node.block = !node.inline;
-
-        if (/^\s*$/.test(text)) {
-            node.text = '';
-            node.raws.left = text;
-            node.raws.right = '';
-        } else {
-            const match = text.match(/^(\s*)([^]*[^\s])(\s*)$/);
-
-            node.text = match[2];
-
-            // Add extra spaces to generate a comment in a common style /*[space][text][space]*/
-            node.raws.left = match[1] || ' ';
-            node.raws.right = match[3] || ' ';
-        }
-    }
-
-    /**
-     * @description Create a Rule node
-     * @param options {{start: number, params: Array}}
-     */
-    createRule (options) {
-        const node = this.rule(this.tokens.slice(options.start, this.pos + 1));
-
-        /**
-         * By default in PostCSS `Rule.params` is `undefined`. There are rules to save the compability with PostCSS:
-         *  - Don't set empty params for Rule node.
-         *  - Set params fro Rule node only if it can be a mixin or &:extend rule.
-         */
-        if (options.params[0] && (options.mixin || options.extend)) {
-            this.raw(this.current, 'params', options.params);
-        }
-
-        if (options.empty) {
-
-            if (options.extend) {
-                this.current.extend = true;
-            }
-
-            if (options.mixin) {
-                this.current.mixin = true;
-            }
-
-            /**
-             * @description Mark mixin without declarations.
-             * @type {boolean}
-             */
-            this.current.empty = true;
-
-            // eslint-disable-next-line
-            delete this.current.nodes;
-
-            if (this.current.selector.indexOf('!important') >= 0) {
-                this.current.important = true;
-            }
-
-            this.pos--;
-
-            this.end(this.tokens[this.pos]);
-        }
-    }
-
-    /**
-     * @description Create a Declaration
-     * @param options {{start: number}}
-     */
-    createDeclaration (options) {
-        this.decl(this.tokens.slice(options.start, this.pos + 1));
-    }
-
-    /**
-     * @description
-     * @param options
-     * @returns {boolean}
-     */
-    processEndOfRule (options) {
-        const {start} = options;
-
-        if (options.extend || options.mixin) {
-            this.createRule(Object.assign(options, {empty: true}));
-            return true;
-        }
-
-        if (options.colon) {
-            if (options.isEndOfBlock) {
-                while (this.pos > start) {
-                    const token = this.tokens[this.pos][0];
-
-                    if (token !== 'space' && token !== 'comment') {
-                        break;
-                    }
-
-                    this.pos -= 1;
-                }
-            }
-
-            this.createDeclaration({start});
-            return true;
-        }
-
-        return false;
-    }
-
     /* eslint-disable max-statements, complexity */
     other () {
         let end = false;
@@ -258,7 +209,7 @@ export default class LessParser extends Parser {
                 brackets.push(type === '(' ? ')' : ']');
             } else if (brackets.length === 0) {
                 if (type === ';') {
-                    const foundEndOfRule = this.processEndOfRule({
+                    const foundEndOfRule = this.ruleEnd({
                         start,
                         params,
                         colon,
@@ -307,7 +258,7 @@ export default class LessParser extends Parser {
 
         // dont process an end of rule if there's only one token and it's unknown (#64)
         if (end && this.tokens.length > 1) {
-            const foundEndOfRule = this.processEndOfRule({
+            const foundEndOfRule = this.ruleEnd({
                 start,
                 params,
                 colon,
@@ -322,6 +273,51 @@ export default class LessParser extends Parser {
         }
 
         this.unknownWord(start);
+    }
+
+    rule (tokens) {
+        tokens.pop();
+
+        const node = new Rule();
+
+        this.init(node, tokens[0][2], tokens[0][3]);
+
+        node.raws.between = this.spacesFromEnd(tokens);
+
+        this.raw(node, 'selector', tokens);
+        this.current = node;
+    }
+
+    ruleEnd (options) {
+        const {start} = options;
+
+        if (options.extend || options.mixin) {
+            this.createRule(Object.assign(options, {empty: true}));
+            return true;
+        }
+
+        if (options.colon) {
+            if (options.isEndOfBlock) {
+                while (this.pos > start) {
+                    const token = this.tokens[this.pos][0];
+
+                    if (token !== 'space' && token !== 'comment') {
+                        break;
+                    }
+
+                    this.pos -= 1;
+                }
+            }
+
+            this.createDeclaration({start});
+            return true;
+        }
+
+        return false;
+    }
+
+    tokenize () {
+        this.tokens = lessTokenizer(this.input);
     }
 
     /* eslint-enable max-statements, complexity */

--- a/lib/less-stringifier.js
+++ b/lib/less-stringifier.js
@@ -19,11 +19,11 @@ export default class LessStringifier extends Stringifier {
     }
 
     block (node, start) {
-        const {ruleWithoutBody} = node;
+        const {empty} = node;
         const between = this.raw(node, 'between', 'beforeOpen');
         let after = '';
 
-        if (ruleWithoutBody) {
+        if (empty) {
             this.builder(start + between, node, 'start');
         } else {
             this.builder(`${ start + between }{`, node, 'start');
@@ -40,7 +40,7 @@ export default class LessStringifier extends Stringifier {
             this.builder(after);
         }
 
-        if (!ruleWithoutBody) {
+        if (!empty) {
             this.builder('}', node, 'end');
         }
     }

--- a/lib/less-stringifier.js
+++ b/lib/less-stringifier.js
@@ -18,6 +18,20 @@ export default class LessStringifier extends Stringifier {
         }
     }
 
+    rule (node) {
+        super.rule(node);
+
+        if (node.empty && node.raws.semicolon) {
+            if (node.important) {
+                this.builder(' !important');
+            }
+
+            if (node.raws.semicolon) {
+                this.builder(';');
+            }
+        }
+    }
+
     block (node, start) {
         const {empty} = node;
         const between = this.raw(node, 'between', 'beforeOpen');

--- a/test/parser/extend.spec.js
+++ b/test/parser/extend.spec.js
@@ -34,7 +34,7 @@ describe('Parser', () => {
             expect(root.first.selector).to.eql('.a');
             expect(root.first.first.selector).to.eql('&:extend(.bucket tr)');
             expect(root.first.first.params).to.eql('(.bucket tr)');
-            expect(root.first.first.extendRule).to.eql(true);
+            expect(root.first.first.extend).to.eql(true);
             expect(root.first.first.toString()).to.be.eql('&:extend(.bucket tr)');
         });
 

--- a/test/parser/extend.spec.js
+++ b/test/parser/extend.spec.js
@@ -35,7 +35,7 @@ describe('Parser', () => {
             expect(root.first.first.selector).to.eql('&:extend(.bucket tr)');
             expect(root.first.first.params).to.eql('(.bucket tr)');
             expect(root.first.first.extend).to.eql(true);
-            expect(root.first.first.toString()).to.be.eql('&:extend(.bucket tr)');
+            expect(root.first.first.toString()).to.be.eql('&:extend(.bucket tr);');
         });
 
         it('parses :extend() after selector', () => {

--- a/test/parser/mixins.spec.js
+++ b/test/parser/mixins.spec.js
@@ -26,7 +26,7 @@ describe('Parser', () => {
                 expect(root.first.type).to.eql('rule');
                 expect(root.first.selector).to.eql('.mixin-name (#FFF)');
                 expect(root.first.params).to.eql('(#FFF)');
-                expect(root.first.ruleWithoutBody).to.eql(true);
+                expect(root.first.empty).to.eql(true);
                 expect(root.first.nodes).to.be.an('undefined');
                 expect(root.first.toString()).to.be.eql('.mixin-name (#FFF)');
             });
@@ -37,7 +37,7 @@ describe('Parser', () => {
                 expect(root.first.first.type).to.eql('rule');
                 expect(root.first.first.selector).to.eql('.mixin-name');
                 expect(root.first.params).to.be.an('undefined');
-                expect(root.first.first.ruleWithoutBody).to.eql(true);
+                expect(root.first.first.empty).to.eql(true);
                 expect(root.first.first.nodes).to.be.an('undefined');
             });
         });
@@ -134,7 +134,7 @@ describe('Parser', () => {
                 expect(root.first.selector).to.eql('header');
                 expect(root.first.first.selector).to.eql(ruleSet);
                 expect(root.first.first.params).to.eql(params, 'Mixin rule set. Invalid params');
-                expect(root.first.first.ruleWithoutBody).to.eql(true);
+                expect(root.first.first.empty).to.eql(true);
                 expect(root.first.first.nodes).to.be.an('undefined');
             });
 

--- a/test/parser/mixins.spec.js
+++ b/test/parser/mixins.spec.js
@@ -28,7 +28,7 @@ describe('Parser', () => {
                 expect(root.first.params).to.eql('(#FFF)');
                 expect(root.first.empty).to.eql(true);
                 expect(root.first.nodes).to.be.an('undefined');
-                expect(root.first.toString()).to.be.eql('.mixin-name (#FFF)');
+                expect(root.first.toString()).to.be.eql('.mixin-name (#FFF);');
             });
 
             it('mixin without body #2', () => {
@@ -122,7 +122,7 @@ describe('Parser', () => {
 
                 const root = parse(code);
 
-                expect(root.first.selector).to.eql('.foo() !important');
+                expect(root.first.selector).to.eql('.foo()');
                 expect(root.first.important).to.eql(true);
             });
 


### PR DESCRIPTION
**Which issue #** if any, does this resolve? fixes #70

<!-- PRs must be accompanied by related tests -->

Please check one:
- [x] New tests created for this change
- [x] Tests updated for this change

This PR:
- [ ] Adds new API
- [ ] Extends existing API, backwards-compatible
- [x] Introduces a breaking change
- [x] Fixes a bug

---

Commits in this PR will be part of a 1.0.0 release.

@evilebottnawi this should fix #70 and correct the `semicolon` and `after` raws properties. Please give this PR a test and let me know what you find.
