### PR TITLE
less-parser: Handle edge case with single token mixins.

### DIFF
--- a/lib/less-parser.js
+++ b/lib/less-parser.js
@@ -321,6 +321,11 @@ export default class LessParser extends Parser {
 
     // dont process an end of rule if there's only one token and it's unknown (#64)
     if (end && this.tokens.length > 1) {
+      // Handle the case where the there is only a single token in the end rule.
+      if (start === this.pos) {
+        this.pos += 1;
+      }
+
       const foundEndOfRule = this.ruleEnd({
         start,
         params,

--- a/test/parser/mixins.spec.js
+++ b/test/parser/mixins.spec.js
@@ -36,9 +36,9 @@ describe('Parser', () => {
 
         expect(root.first.first.type).to.eql('rule');
         expect(root.first.first.selector).to.eql('.mixin-name');
-        expect(root.first.params).to.be.an('undefined');
+        expect(root.first.params).to.be.undefined;
         expect(root.first.first.empty).to.eql(true);
-        expect(root.first.first.nodes).to.be.an('undefined');
+        expect(root.first.first.nodes).to.be.undefined;
       });
 
       it('mixin without body and without whitespace #2', () => {
@@ -46,9 +46,9 @@ describe('Parser', () => {
 
         expect(root.first.first.type).to.eql('rule');
         expect(root.first.first.selector).to.eql('.mixin-name');
-        expect(root.first.params).to.be.an('undefined');
+        expect(root.first.params).to.be.undefined;
         expect(root.first.first.empty).to.eql(true);
-        expect(root.first.first.nodes).to.be.an('undefined');
+        expect(root.first.first.nodes).to.be.undefined;
       });
     });
 

--- a/test/parser/mixins.spec.js
+++ b/test/parser/mixins.spec.js
@@ -40,6 +40,16 @@ describe('Parser', () => {
         expect(root.first.first.empty).to.eql(true);
         expect(root.first.first.nodes).to.be.an('undefined');
       });
+
+      it('mixin without body and without whitespace #2', () => {
+        const root = parse('.base {.mixin-name}');
+
+        expect(root.first.first.type).to.eql('rule');
+        expect(root.first.first.selector).to.eql('.mixin-name');
+        expect(root.first.params).to.be.an('undefined');
+        expect(root.first.first.empty).to.eql(true);
+        expect(root.first.first.nodes).to.be.an('undefined');
+      });
     });
 
     describe('Nested mixin', () => {


### PR DESCRIPTION
The parser didn't account for mixins that were used in the following manner:

```
.foo {.my-mixin}
```

Please check one:
- [x] New tests created for this change
- [ ] Tests updated for this change

This PR:
- [ ] Adds new API
- [ ] Extends existing API, backwards-compatible
- [ ] Introduces a breaking change
- [x] Fixes a bug
