### PR TITLE
Supply a Root stringifier

### DIFF
--- a/lib/less-parser.js
+++ b/lib/less-parser.js
@@ -2,6 +2,7 @@ import Comment from 'postcss/lib/comment';
 import Import from './import';
 import Parser from 'postcss/lib/parser';
 import Rule from './rule';
+import Root from './root';
 import findExtendRule from './find-extend-rule';
 import isMixinToken from './is-mixin-token';
 import lessTokenizer from './less-tokenize';
@@ -9,6 +10,14 @@ import lessTokenizer from './less-tokenize';
 const blockCommentEndPattern = /\*\/$/;
 
 export default class LessParser extends Parser {
+
+  constructor (input) {
+    super(input);
+
+    this.root = new Root();
+    this.current = this.root;
+    this.root.source = { input, start: { line: 1, column: 1 } };
+  }
 
   atrule (token) {
     if (token[1] === '@import') {

--- a/lib/root.js
+++ b/lib/root.js
@@ -1,0 +1,14 @@
+import PostCssRoot from 'postcss/lib/root';
+import stringify from './less-stringify';
+
+export default class Root extends PostCssRoot {
+  toString (stringifier) {
+    if (!stringifier) {
+      stringifier = {
+        stringify
+      };
+    }
+
+    return super.toString(stringifier);
+  }
+}

--- a/test/postcss.spec.js
+++ b/test/postcss.spec.js
@@ -62,4 +62,16 @@ describe('#postcss', () => {
         done();
       }).catch(done);
   });
+
+  it('should create its own Root node stringifier (#82)', (done) => {
+    const lessText = '@import "foo.less"';
+
+    postcss()
+      .process(lessText, { syntax: lessSyntax })
+      .then((result) => {
+        expect(result.root.toString()).to.eql(lessText);
+
+        done();
+      }).catch(done);
+  });
 });


### PR DESCRIPTION
**Which issue #** if any, does this resolve?
No issue, see #81 for some related discussion.

<!-- PRs must be accompanied by related tests -->

I'm not really sure how to test this, if I come up with something I'll complete this PR with it.

Please check one:
- [ ] New tests created for this change
- [ ] Tests updated for this change

This PR:
- [ ] Adds new API
- [x] Extends existing API, backwards-compatible
- [ ] Introduces a breaking change
- [ ] Fixes a bug

---

I discovered that stringifying the `Root` node when it contains `Import` nodes would cause problems if the `postcss-less` stringifier wasn't supplied. However, it's not always possible to pass the stringifier and thus, the stringifying would fail.

Creating our own `Root` node with a stringifier (extending from the regular `postcss` `Root` node) we can supply our stringifier straight from the start and it'll always be used without the caller having to do anything.
