### PR TITLE
Test case for #92

### DIFF
--- a/test/parser/variables.spec.js
+++ b/test/parser/variables.spec.js
@@ -13,6 +13,13 @@ describe('Parser', () => {
       expect(root.first.value).to.eql('1');
     });
 
+    it('parses variables with whitespaces between name and ":"', () => {
+      let root = parse('@onespace : 42;');
+
+      expect(root.first.prop).to.eql('@onespace');
+      expect(root.first.value).to.eql('42');
+    });
+
     it('parses string variables', () => {
       const root = parse('@var: "test";');
 


### PR DESCRIPTION
So test case for #92

<!-- PRs must be accompanied by related tests -->

Please check one:
- [x] New tests created for this change
- [ ] Tests updated for this change

This PR:
- [ ] Fixes a bug

---

<!-- add additional comments here -->
### Globals

At first i thought [RegExp from globals.js](https://github.com/shellscape/postcss-less/blob/master/lib/tokenizer/globals.js#L31) needed fixin:, I was __wrong__ it matches `@var:` and `@var :`.
So I tried with parsing

### Tokenize at rule
 
Running tests (new one included), I pin pointed [tokenize-at-rule.js#L36](https://github.com/shellscape/postcss-less/blob/master/lib/tokenizer/tokenize-at-rule.js#L36).
When declaration contains a space between _variable name_ and `:`,
It makes `state.cssPart` one character to shorter to enter [word definition bloc](https://github.com/shellscape/postcss-less/blob/master/lib/tokenizer/tokenize-at-rule.js#L50-L62).

Is it the way to go or am I doing it wrong?

Regards