### PR TITLE
Allow space between ! and important for mixins

### DIFF
--- a/lib/less-parser.js
+++ b/lib/less-parser.js
@@ -114,9 +114,14 @@ export default class LessParser extends Parser {
       // eslint-disable-next-line
       delete this.current.nodes;
 
-      if (/!important/i.test(node.selector)) {
+      if (/!\s*important/i.test(node.selector)) {
         node.important = true;
-        node.selector = node.selector.replace(/\s*!important/i, '');
+
+        if (/\s*!\s+important/i.test(node.selector)) {
+          node.raws.important = node.selector.match(/(\s*!\s+important)/i)[1];
+        }
+
+        node.selector = node.selector.replace(/\s*!\s*important/i, '');
       }
 
       // rules don't have trailing semicolons in vanilla css, so they get

--- a/test/parser/mixins.spec.js
+++ b/test/parser/mixins.spec.js
@@ -158,6 +158,23 @@ describe('Parser', () => {
         expect(root.first.important).to.eql(true);
       });
 
+      it('parses nested mixins with `! important`', () => {
+        const code = `
+                    .foo() ! important;
+                    .bar()! important;
+                `;
+
+        const root = parse(code);
+
+        expect(root.first.selector).to.eql('.foo()');
+        expect(root.first.important).to.eql(true);
+        expect(root.first.raws.important).to.eql(' ! important');
+
+        expect(root.last.selector).to.eql('.bar()');
+        expect(root.last.important).to.eql(true);
+        expect(root.last.raws.important).to.eql('! important');
+      });
+
       it('parses nested mixins with the rule set', () => {
         const params = '({background-color: red;})';
         const ruleSet = `.desktop-and-old-ie ${ params }`;


### PR DESCRIPTION
**Which issue #** if any, does this resolve?
#87

<!-- PRs must be accompanied by related tests -->

Please check one:
- [x] New tests created for this change
- [ ] Tests updated for this change

This PR:
- [ ] Adds new API
- [ ] Extends existing API, backwards-compatible
- [ ] Introduces a breaking change
- [x] Fixes a bug

---

This behaves like PostCSS, only adding `node.raws.important` when it's not `!important`. I also noticed there was a failing test unrelated to this change which I've left untouched.