### PR TITLE
#96 - Add extra check for not adding params from brackets.

### DIFF
--- a/lib/less-parser.js
+++ b/lib/less-parser.js
@@ -316,7 +316,7 @@ export default class LessParser extends Parser {
         }
       }
 
-      // we don't want to add params for pseudo-selectors that utilize parens (#56)
+      // we don't want to add params for pseudo-selectors that utilize parens (#56) or bracket selectors (#96)
       if ((extend || !colon) && (brackets.length > 0 || type === 'brackets' || params[0]) && brackets[0] !== ']') {
         params.push(token);
       }

--- a/lib/less-parser.js
+++ b/lib/less-parser.js
@@ -317,7 +317,7 @@ export default class LessParser extends Parser {
       }
 
       // we don't want to add params for pseudo-selectors that utilize parens (#56)
-      if ((extend || !colon) && (brackets.length > 0 || type === 'brackets' || params[0])) {
+      if ((extend || !colon) && (brackets.length > 0 || type === 'brackets' || params[0]) && brackets[0] !== ']') {
         params.push(token);
       }
 

--- a/test/parser/params.spec.js
+++ b/test/parser/params.spec.js
@@ -15,5 +15,13 @@ describe('Parser', () => {
       expect(root.first.params).to.be.undefined;
     });
 
+    it('should not assign parameters for bracket selectors', () => {
+      const code = '.test1,.test2[test=test] {}';
+      const root = parse(code);
+
+      expect(root.first.selector).to.eql('.test1,.test2[test=test]');
+      expect(root.first.params).to.be.undefined;
+    });
+
   });
 });


### PR DESCRIPTION
Hopefully Fixes #96.

Please check one:
- [X] New tests created for this change
- [ ] Tests updated for this change

This PR:
- [ ] Adds new API
- [ ] Extends existing API, backwards-compatible
- [ ] Introduces a breaking change
- [X] Fixes a bug

---

After looking through the less documentation I have not found any mixin or extend syntax that uses brackets `[]`. The Idea is to not fill `params` with brackets.
