### PR TITLE
Handle spaces between variable name and colon

### DIFF
--- a/lib/tokenizer/tokenize-at-rule.js
+++ b/lib/tokenizer/tokenize-at-rule.js
@@ -35,9 +35,14 @@ export default function tokenizeAtRule (state) {
   else {
     atEndPattern.lastIndex = state.pos + 1;
     atEndPattern.test(state.css);
+    const spaceColonPos = state.css.indexOf(' :', state.pos);
 
     if (atEndPattern.lastIndex === 0) {
       state.nextPos = state.css.length - 1;
+    }
+    // for cases where there is extra whitespace between a variable name and ":" (#92)
+    else if (spaceColonPos > state.pos && state.css.slice(state.pos, state.pos + 5) !== "@page") {
+      state.nextPos = spaceColonPos + 1;
     }
     else {
       state.nextPos = atEndPattern.lastIndex - 2;

--- a/test/parser/variables.spec.js
+++ b/test/parser/variables.spec.js
@@ -14,6 +14,20 @@ describe('Parser', () => {
     });
 
     it('parses variables with whitespaces between name and ":"', () => {
+      let root = parse('@onespace : 42;');
+
+      expect(root.first.prop).to.eql('@onespace');
+      expect(root.first.value).to.eql('42');
+    });
+
+    it('parses variables with no whitespace between ":" and value', () => {
+      const root = parse('@var :42;');
+
+      expect(root.first.prop).to.eql('@var');
+      expect(root.first.value).to.eql('42');
+    });
+
+    it('parses mutliple variables with whitespaces between name and ":"', () => {
       const root = parse('@foo  : 42; @bar : 35;');
 
       expect(root.first.prop).to.eql('@foo');
@@ -22,7 +36,7 @@ describe('Parser', () => {
       expect(root.nodes[1].value).to.eql('35');
     });
 
-    it('parses variables with no whitespace between ":" and value', () => {
+    it('parses multiple variables with no whitespace between ":" and value', () => {
       const root = parse('@foo  :42; @bar :35');
 
       expect(root.first.prop).to.eql('@foo');

--- a/test/parser/variables.spec.js
+++ b/test/parser/variables.spec.js
@@ -14,10 +14,21 @@ describe('Parser', () => {
     });
 
     it('parses variables with whitespaces between name and ":"', () => {
-      let root = parse('@onespace : 42;');
+      const root = parse('@foo  : 42; @bar : 35;');
 
-      expect(root.first.prop).to.eql('@onespace');
+      expect(root.first.prop).to.eql('@foo');
       expect(root.first.value).to.eql('42');
+      expect(root.nodes[1].prop).to.eql('@bar');
+      expect(root.nodes[1].value).to.eql('35');
+    });
+
+    it('parses variables with no whitespace between ":" and value', () => {
+      const root = parse('@foo  :42; @bar :35');
+
+      expect(root.first.prop).to.eql('@foo');
+      expect(root.first.value).to.eql('42');
+      expect(root.nodes[1].prop).to.eql('@bar');
+      expect(root.nodes[1].value).to.eql('35');
     });
 
     it('parses string variables', () => {

--- a/test/tokenize.spec.js
+++ b/test/tokenize.spec.js
@@ -169,5 +169,24 @@ describe('#tokenize()', () => {
         [')', ')', 1, 7]
       ]);
     });
+
+    it('tokenizes @page with extra whitespace', () => {
+      testTokens('@page   :left { margin: 0; }', [
+        [ 'at-word', '@page', 1, 1, 1, 5 ],
+        [ 'space', '   ' ],
+        [ ':', ':', 1, 9 ],
+        [ 'word', 'left', 1, 10, 1, 13 ],
+        [ 'space', ' ' ],
+        [ '{', '{', 1, 15 ],
+        [ 'space', ' ' ],
+        [ 'word', 'margin', 1, 17, 1, 22 ],
+        [ ':', ':', 1, 23 ],
+        [ 'space', ' ' ],
+        [ 'word', '0', 1, 25, 1, 25 ],
+        [ ';', ';', 1, 26 ],
+        [ 'space', ' ' ],
+        [ '}', '}', 1, 28 ]
+      ]);
+    });
   });
 });


### PR DESCRIPTION
Fixes #92

<!-- PRs must be accompanied by related tests -->

Please check one:
- [x] New tests created for this change
- [x] Tests updated for this change

This PR:
- [ ] Adds new API
- [ ] Extends existing API, backwards-compatible
- [ ] Introduces a breaking change
- [x] Fixes a bug

---

<!-- add additional comments here -->
