### PR TITLE
Handle spaces between variable name and colon

### DIFF
--- a/lib/tokenizer/tokenize-at-rule.js
+++ b/lib/tokenizer/tokenize-at-rule.js
@@ -35,9 +35,19 @@ export default function tokenizeAtRule (state) {
   else {
     atEndPattern.lastIndex = state.pos + 1;
     atEndPattern.test(state.css);
+    const spaceColonPos = state.css.indexOf(' :', state.pos);
 
     if (atEndPattern.lastIndex === 0) {
       state.nextPos = state.css.length - 1;
+    }
+    // for cases where there is extra whitespace between a variable name and ":" (#92)
+    // the regex passes if there is only whitespace (or nothing) between the at-word and " :"
+    else if (
+        spaceColonPos > state.pos &&
+        /^\s*$/.test(state.css.slice(state.css.indexOf(' ', state.pos), spaceColonPos)) &&
+        state.css.slice(state.pos, state.pos + 5) !== "@page"
+    ) {
+      state.nextPos = spaceColonPos + 1;
     }
     else {
       state.nextPos = atEndPattern.lastIndex - 2;

--- a/test/parser/variables.spec.js
+++ b/test/parser/variables.spec.js
@@ -24,39 +24,39 @@ describe('Parser', () => {
     });
 
     // #98 was merged to resolve this but broke other scenarios
-    it('parses variables with whitespaces between name and ":"'); //, () => {
-    //   let root = parse('@onespace : 42;');
-    //
-    //   expect(root.first.prop).to.eql('@onespace');
-    //   expect(root.first.value).to.eql('42');
-    // });
+    it('parses variables with whitespaces between name and ":"', () => {
+      let root = parse('@onespace : 42;');
+
+      expect(root.first.prop).to.eql('@onespace');
+      expect(root.first.value).to.eql('42');
+    });
 
     // #98 was merged to resolve this but broke other scenarios
     // these tests are commented out until that is resolved
-    it('parses variables with no whitespace between ":" and value'); //, () => {
-    //   const root = parse('@var :42;');
-    //
-    //   expect(root.first.prop).to.eql('@var');
-    //   expect(root.first.value).to.eql('42');
-    // });
-    //
-    it('parses mutliple variables with whitespaces between name and ":"'); //, () => {
-    //   const root = parse('@foo  : 42; @bar : 35;');
-    //
-    //   expect(root.first.prop).to.eql('@foo');
-    //   expect(root.first.value).to.eql('42');
-    //   expect(root.nodes[1].prop).to.eql('@bar');
-    //   expect(root.nodes[1].value).to.eql('35');
-    // });
-    //
-    it('parses multiple variables with no whitespace between ":" and value'); //, () => {
-    //   const root = parse('@foo  :42; @bar :35');
-    //
-    //   expect(root.first.prop).to.eql('@foo');
-    //   expect(root.first.value).to.eql('42');
-    //   expect(root.nodes[1].prop).to.eql('@bar');
-    //   expect(root.nodes[1].value).to.eql('35');
-    // });
+    it('parses variables with no whitespace between ":" and value', () => {
+      const root = parse('@var :42;');
+
+      expect(root.first.prop).to.eql('@var');
+      expect(root.first.value).to.eql('42');
+    });
+
+    it('parses multiple variables with whitespaces between name and ":"', () => {
+      const root = parse('@foo  : 42; @bar : 35;');
+
+      expect(root.first.prop).to.eql('@foo');
+      expect(root.first.value).to.eql('42');
+      expect(root.nodes[1].prop).to.eql('@bar');
+      expect(root.nodes[1].value).to.eql('35');
+    });
+
+    it('parses multiple variables with no whitespace between ":" and value', () => {
+      const root = parse('@foo  :42; @bar :35');
+
+      expect(root.first.prop).to.eql('@foo');
+      expect(root.first.value).to.eql('42');
+      expect(root.nodes[1].prop).to.eql('@bar');
+      expect(root.nodes[1].value).to.eql('35');
+    });
 
     it('parses string variables', () => {
       const root = parse('@var: "test";');

--- a/test/tokenize.spec.js
+++ b/test/tokenize.spec.js
@@ -169,24 +169,55 @@ describe('#tokenize()', () => {
         [')', ')', 1, 7]
       ]);
     });
-    //
-    // it('tokenizes @page with extra whitespace', () => {
-    //   testTokens('@page   :left { margin: 0; }', [
-    //     [ 'at-word', '@page', 1, 1, 1, 5 ],
-    //     [ 'space', '   ' ],
-    //     [ ':', ':', 1, 9 ],
-    //     [ 'word', 'left', 1, 10, 1, 13 ],
-    //     [ 'space', ' ' ],
-    //     [ '{', '{', 1, 15 ],
-    //     [ 'space', ' ' ],
-    //     [ 'word', 'margin', 1, 17, 1, 22 ],
-    //     [ ':', ':', 1, 23 ],
-    //     [ 'space', ' ' ],
-    //     [ 'word', '0', 1, 25, 1, 25 ],
-    //     [ ';', ';', 1, 26 ],
-    //     [ 'space', ' ' ],
-    //     [ '}', '}', 1, 28 ]
-    //   ]);
-    // });
+
+    it('tokenizes @page with extra whitespace', () => {
+      testTokens('@page   :left { margin: 0; }', [
+        [ 'at-word', '@page', 1, 1, 1, 5 ],
+        [ 'space', '   ' ],
+        [ ':', ':', 1, 9 ],
+        [ 'word', 'left', 1, 10, 1, 13 ],
+        [ 'space', ' ' ],
+        [ '{', '{', 1, 15 ],
+        [ 'space', ' ' ],
+        [ 'word', 'margin', 1, 17, 1, 22 ],
+        [ ':', ':', 1, 23 ],
+        [ 'space', ' ' ],
+        [ 'word', '0', 1, 25, 1, 25 ],
+        [ ';', ';', 1, 26 ],
+        [ 'space', ' ' ],
+        [ '}', '}', 1, 28 ]
+      ]);
+    });
+
+    it('tokenizes at-words with extra whitespace around colons', () => {
+      testTokens('@supports (display : flex) { body { display : flex; } }', [
+        [ 'at-word', '@supports', 1, 1, 1, 9 ],
+        [ 'space', ' ' ],
+        [ 'brackets', '(display : flex)', 1, 11, 1, 26 ],
+        [ 'space', ' ' ],
+        [ '{', '{', 1, 28 ],
+        [ 'space', ' ' ],
+        [ 'word', 'body', 1, 30, 1, 33 ],
+        [ 'space', ' ' ],
+        [ '{', '{', 1, 35 ],
+        [ 'space', ' ' ],
+        [ 'word', 'display', 1, 37, 1, 43 ],
+        [ 'space', ' ' ],
+        [ ':', ':', 1, 45 ],
+        [ 'space', ' ' ],
+        [ 'word', 'flex', 1, 47, 1, 50 ],
+        [ ';', ';', 1, 51 ],
+        [ 'space', ' ' ],
+        [ '}', '}', 1, 53 ],
+        [ 'space', ' ' ],
+        [ '}', '}', 1, 55 ]
+      ]);
+      testTokens('@import "weird  :  filename.css";', [
+        [ 'at-word', '@import', 1, 1, 1, 7 ],
+        [ 'space', ' ' ],
+        [ 'string', '"weird  :  filename.css"', 1, 9, 1, 32 ],
+        [ ';', ';', 1, 33 ]
+      ]);
+    });
   });
 });


### PR DESCRIPTION
Fixes #92

<!-- PRs must be accompanied by related tests -->

Please check one:
- [x] New tests created for this change
- [ ] Tests updated for this change

This PR:
- [ ] Adds new API
- [ ] Extends existing API, backwards-compatible
- [ ] Introduces a breaking change
- [x] Fixes a bug

---

The previous solution I had wasnt checking that the at-word was directly next to the " :". So in the wikimedia file the ` :last-child` was passing the condition for the `@import` statement even though theyre not next to each other.

```less
@import 'mediawiki.mixins';

li {
  &:not( :last-child ) {
    margin-bottom: 16px;
  }
}
````

I added another line that checks that the at-word and " :" have nothing else between them. And I believe that `@page` is the only at-rule that can have a colon directly after it.