### PR TITLE
fix: mixin parameters with functions. fixes #122

### DIFF
--- a/lib/LessParser.js
+++ b/lib/LessParser.js
@@ -82,6 +82,10 @@ module.exports = class LessParser extends Parser {
   }
 
   unknownWord(tokens) {
+    // NOTE: keep commented for examining unknown structures
+    // console.log('unknown', tokens);
+    // console.log(this.root.first);
+
     const [first] = tokens;
 
     // TODO: move this into a util function/file
@@ -92,7 +96,7 @@ module.exports = class LessParser extends Parser {
       let important = '';
 
       // fix for #86. if rulesets are mixin params, they need to be converted to a brackets token
-      if (bracketsIndex < 0 && firstParenIndex > 0) {
+      if ((bracketsIndex < 0 || bracketsIndex > 3) && firstParenIndex > 0) {
         const lastParenIndex = tokens.findIndex((t) => t[0] === ')');
 
         const contents = tokens.slice(firstParenIndex, lastParenIndex + firstParenIndex);
@@ -125,28 +129,14 @@ module.exports = class LessParser extends Parser {
       this.lastNode.mixin = true;
       this.lastNode.raws.identifier = identifier;
 
-      // const importantIndex = tokens.findIndex((t) => importantPattern.test(t[1]));
-
       if (important) {
         this.lastNode.important = true;
         this.lastNode.raws.important = important;
       }
 
-      // if (importantIndex > 0) {
-      //   nodes.splice(importantIndex, 1);
-      // [this.lastNode.raws.important] = this.lastNode.params.match(importantPattern);
-
-      // this.lastNode.params = this.lastNode.params.replace(importantPattern, '');
-
-      // const [spaces] = this.lastNode.params.match(/\s+$/) || [''];
-      // this.lastNode.raws.between = spaces;
-      // this.lastNode.params = this.lastNode.params.trim();
-      // }
-
       return;
     }
-    // NOTE: keep commented for examining unknown structures
-    // console.log('unknown', tokens);
+
     super.unknownWord(tokens);
   }
 };

--- a/test/parser/mixins.test.js
+++ b/test/parser/mixins.test.js
@@ -268,3 +268,19 @@ test('important in parameters (#102)', (t) => {
   t.falsy(first.important);
   t.is(nodeToString(root), less);
 });
+
+test('mixin parameters keyframes (#122)', (t) => {
+  const less = `.mixin({
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+});`;
+  const root = parse(less);
+  const { first } = root;
+
+  t.is(first.name, 'mixin');
+  t.is(nodeToString(root), less);
+});

--- a/test/parser/mixins.test.js
+++ b/test/parser/mixins.test.js
@@ -269,7 +269,7 @@ test('important in parameters (#102)', (t) => {
   t.is(nodeToString(root), less);
 });
 
-test('mixin parameters keyframes (#122)', (t) => {
+test('mixin parameters with functions (#122)', (t) => {
   const less = `.mixin({
   0% {
     transform: rotate(0deg);


### PR DESCRIPTION
**Which issue #** if any, does this resolve?

<!-- PRs must be accompanied by related tests -->

Please check one:
- [x] New tests created for this change
- [ ] Tests updated for this change

This PR:
- [ ] Adds new API
- [ ] Extends existing API, backwards-compatible
- [ ] Introduces a breaking change
- [x] Fixes a bug

---

Fixes #122. When mixing parameters contain declarations with functions (or any other declaration that contains parenthesis pairs), the parser was throwing a syntax error.
