### PR TITLE
feat: support less each function

### DIFF
--- a/lib/LessParser.js
+++ b/lib/LessParser.js
@@ -28,6 +28,25 @@ module.exports = class LessParser extends Parser {
     variableNode(this.lastNode);
   }
 
+  each(tokens) {
+    // prepend a space so the `name` will be parsed correctly
+    tokens[0][1] = ` ${tokens[0][1]}`;
+
+    const firstParenIndex = tokens.findIndex((t) => t[0] === '(');
+    const lastParen = tokens.reverse().find((t) => t[0] === ')');
+    const lastParenIndex = tokens.reverse().indexOf(lastParen);
+    const paramTokens = tokens.splice(firstParenIndex, lastParenIndex);
+    const params = paramTokens.map((t) => t[1]).join('');
+
+    for (const token of tokens.reverse()) {
+      this.tokenizer.back(token);
+    }
+
+    this.atrule(this.tokenizer.nextToken());
+    this.lastNode.function = true;
+    this.lastNode.params = params;
+  }
+
   init(node, line, column) {
     super.init(node, line, column);
     this.lastNode = node;
@@ -50,6 +69,53 @@ module.exports = class LessParser extends Parser {
     } else {
       const match = text.match(/^(\s*)([^]*[^\s])(\s*)$/);
       [, node.raws.left, node.text, node.raws.right] = match;
+    }
+  }
+
+  mixin(tokens) {
+    const [first] = tokens;
+    const identifier = first[1].slice(0, 1);
+    const bracketsIndex = tokens.findIndex((t) => t[0] === 'brackets');
+    const firstParenIndex = tokens.findIndex((t) => t[0] === '(');
+    let important = '';
+
+    // fix for #86. if rulesets are mixin params, they need to be converted to a brackets token
+    if ((bracketsIndex < 0 || bracketsIndex > 3) && firstParenIndex > 0) {
+      const lastParenIndex = tokens.findIndex((t) => t[0] === ')');
+
+      const contents = tokens.slice(firstParenIndex, lastParenIndex + firstParenIndex);
+      const brackets = contents.map((t) => t[1]).join('');
+      const [paren] = tokens.slice(firstParenIndex);
+      const start = [paren[2], paren[3]];
+      const [last] = tokens.slice(lastParenIndex, lastParenIndex + 1);
+      const end = [last[2], last[3]];
+      const newToken = ['brackets', brackets].concat(start, end);
+
+      const tokensBefore = tokens.slice(0, firstParenIndex);
+      const tokensAfter = tokens.slice(lastParenIndex + 1);
+      tokens = tokensBefore;
+      tokens.push(newToken);
+      tokens = tokens.concat(tokensAfter);
+    }
+
+    const importantIndex = tokens.findIndex((t) => importantPattern.test(t[1]));
+
+    if (importantIndex > 0) {
+      [, important] = tokens[importantIndex];
+      tokens.splice(importantIndex, 1);
+    }
+
+    for (const token of tokens.reverse()) {
+      this.tokenizer.back(token);
+    }
+
+    this.atrule(this.tokenizer.nextToken());
+    this.lastNode.mixin = true;
+    this.lastNode.raws.identifier = identifier;
+
+    if (important) {
+      this.lastNode.important = true;
+      this.lastNode.raws.important = important;
     }
   }
 
@@ -84,56 +150,18 @@ module.exports = class LessParser extends Parser {
   unknownWord(tokens) {
     // NOTE: keep commented for examining unknown structures
     // console.log('unknown', tokens);
-    // console.log(this.root.first);
 
     const [first] = tokens;
 
+    // #121 support `each` - http://lesscss.org/functions/#list-functions-each
+    if (tokens[0][1] === 'each' && tokens[1][0] === '(') {
+      this.each(tokens);
+      return;
+    }
+
     // TODO: move this into a util function/file
     if (isMixinToken(first)) {
-      const identifier = first[1].slice(0, 1);
-      const bracketsIndex = tokens.findIndex((t) => t[0] === 'brackets');
-      const firstParenIndex = tokens.findIndex((t) => t[0] === '(');
-      let important = '';
-
-      // fix for #86. if rulesets are mixin params, they need to be converted to a brackets token
-      if ((bracketsIndex < 0 || bracketsIndex > 3) && firstParenIndex > 0) {
-        const lastParenIndex = tokens.findIndex((t) => t[0] === ')');
-
-        const contents = tokens.slice(firstParenIndex, lastParenIndex + firstParenIndex);
-        const brackets = contents.map((t) => t[1]).join('');
-        const [paren] = tokens.slice(firstParenIndex);
-        const start = [paren[2], paren[3]];
-        const [last] = tokens.slice(lastParenIndex, lastParenIndex + 1);
-        const end = [last[2], last[3]];
-        const newToken = ['brackets', brackets].concat(start, end);
-
-        const tokensBefore = tokens.slice(0, firstParenIndex);
-        const tokensAfter = tokens.slice(lastParenIndex + 1);
-        tokens = tokensBefore;
-        tokens.push(newToken);
-        tokens = tokens.concat(tokensAfter);
-      }
-
-      const importantIndex = tokens.findIndex((t) => importantPattern.test(t[1]));
-
-      if (importantIndex > 0) {
-        [, important] = tokens[importantIndex];
-        tokens.splice(importantIndex, 1);
-      }
-
-      for (const token of tokens.reverse()) {
-        this.tokenizer.back(token);
-      }
-
-      this.atrule(this.tokenizer.nextToken());
-      this.lastNode.mixin = true;
-      this.lastNode.raws.identifier = identifier;
-
-      if (important) {
-        this.lastNode.important = true;
-        this.lastNode.raws.important = important;
-      }
-
+      this.mixin(tokens);
       return;
     }
 

--- a/lib/LessStringifier.js
+++ b/lib/LessStringifier.js
@@ -2,12 +2,13 @@ const Stringifier = require('postcss/lib/stringifier');
 
 module.exports = class LessStringifier extends Stringifier {
   atrule(node, semicolon) {
-    if (!node.mixin && !node.variable) {
+    if (!node.mixin && !node.variable && !node.function) {
       super.atrule(node, semicolon);
       return;
     }
 
-    let name = `${node.raws.identifier || '@'}${node.name}`;
+    const identifier = node.function ? '' : node.raws.identifier || '@';
+    let name = `${identifier}${node.name}`;
     let params = node.params ? this.rawValue(node, 'params') : '';
     const important = node.raws.important || '';
 

--- a/test/parser/function.test.js
+++ b/test/parser/function.test.js
@@ -1,0 +1,20 @@
+const test = require('ava');
+
+const { parse, nodeToString } = require('../../lib');
+
+test('each (#121)', (t) => {
+  const params = `(@colors, {
+  .@{value}-color {
+    color: @value;
+  }
+})`;
+  const less = `each${params};`;
+  const root = parse(less);
+  const { first } = root;
+
+  t.is(first.name, 'each');
+  t.is(first.params, params);
+  t.truthy(first.function);
+
+  t.is(nodeToString(root), less);
+});


### PR DESCRIPTION
**Which issue #** if any, does this resolve?

<!-- PRs must be accompanied by related tests -->

Please check one:
- [x] New tests created for this change
- [ ] Tests updated for this change

This PR:
- [ ] Adds new API
- [x] Extends existing API, backwards-compatible
- [ ] Introduces a breaking change
- [x] Fixes a bug

---

This PR fixes #121 by adding relatively naive support for the new `each` function in LESS. `each` is relatively unique, as it's the only function used at the root level, outside of a ruleset. While this change doesn't do anything special with the params, it allows the parser to continue on without throwing an error.

The result is an `AtRule` with a `function: true` property, and `params` property which contains everything between the first and last, open and closed parenthesis. 

In the future we might examine how to parse and present the params for `each` in the node. 
