### PR TITLE
Correctly calculate last parens in ruleset as mixin param

### DIFF
--- a/lib/LessParser.js
+++ b/lib/LessParser.js
@@ -92,7 +92,7 @@ module.exports = class LessParser extends Parser {
 
     // fix for #86. if rulesets are mixin params, they need to be converted to a brackets token
     if ((bracketsIndex < 0 || bracketsIndex > 3) && firstParenIndex > 0) {
-      const lastParenIndex = tokens.findIndex((t) => t[0] === ')');
+      const lastParenIndex = tokens.reduce((last, t, i) => (t[0] === ')' ? i : last));
 
       const contents = tokens.slice(firstParenIndex, lastParenIndex + firstParenIndex);
       const brackets = contents.map((t) => t[1]).join('');

--- a/test/parser/mixins.test.js
+++ b/test/parser/mixins.test.js
@@ -308,3 +308,20 @@ test('mixin parameters with functions (#122)', (t) => {
   t.is(first.name, 'mixin');
   t.is(nodeToString(root), less);
 });
+
+test('mixin parameters with multiple parens', (t) => {
+  const less = `.mixin({
+  &__icon {
+      background-image: url('./icon.svg');
+      width: calc(~"100% + 1px");
+  }
+});
+.two {}`;
+
+  const root = parse(less);
+  const { first, last } = root;
+
+  t.is(first.name, 'mixin');
+  t.is(last.selector, '.two');
+  t.is(nodeToString(root), less);
+});


### PR DESCRIPTION
**Which issue #** if any, does this resolve?
#128
<!-- PRs must be accompanied by related tests -->

Please check one:
- [x] New tests created for this change
- [ ] Tests updated for this change

This PR:
- [ ] Adds new API
- [ ] Extends existing API, backwards-compatible
- [ ] Introduces a breaking change
- [x] Fixes a bug

---

<!-- add additional comments here -->
The following code found in `lib/LessParser.js:95` always returns the first closing parenthesis rather than the last, as indicated by the variable name.
```js
const lastParenIndex = tokens.findIndex((t) => t[0] === ')');
```
This breaks the parsing when there are multiple closing parenthesis in the list of tokens.