### PR TITLE
Recognize CRLF as EOL in inline comments when retokenizing and add a test for that.

### DIFF
--- a/lib/nodes/inline-comment.js
+++ b/lib/nodes/inline-comment.js
@@ -9,9 +9,9 @@ module.exports = {
       let last;
 
       while (token) {
-        if (/\n/.test(token[1])) {
+        if (/\r?\n/.test(token[1])) {
           // If there are quotes, fix tokenizer creating one token from start quote to end quote
-          if (/['"].*\n/.test(token[1])) {
+          if (/['"].*\r?\n/.test(token[1])) {
             // Add string before newline to inline comment token
             bits.push(token[1].substring(0, token[1].indexOf('\n')));
 

--- a/test/parser/comments.test.js
+++ b/test/parser/comments.test.js
@@ -15,6 +15,22 @@ test('inline comment', (t) => {
   t.is(nodeToString(root), less);
 });
 
+test('two-line inline comment with a single quote and windows EOL', (t) => {
+  const less = `// it's first comment (this line should end with Windows new line symbols)\r\n// it's second comment`;
+  const root = parse(less);
+  const [first, second, ...rest] = root.nodes;
+
+  t.truthy(root);
+  t.true(first instanceof Comment);
+  t.true(first.inline);
+  t.is(first.text, `it's first comment (this line should end with Windows new line symbols)`);
+  t.true(second instanceof Comment);
+  t.true(second.inline);
+  t.is(second.text, `it's second comment`);
+  t.is(nodeToString(root), less);
+  t.is(rest.length, 0);
+});
+
 test('inline comment without leading space', (t) => {
   const less = '//batman';
   const root = parse(less);


### PR DESCRIPTION
**Which issue #** if any, does this resolve?
https://github.com/shellscape/postcss-less/issues/136

Please check one:
- [x] New tests created for this change
- [ ] Tests updated for this change

This PR:
- [ ] Adds new API
- [ ] Extends existing API, backwards-compatible
- [ ] Introduces a breaking change
- [x] Fixes a bug

---

<!-- add additional comments here -->
This fixes a bug that is propagated to stylelint. Ultimately this would result in a new version of stylelint.