### PR TITLE
Enforce LF.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Enforce Unix newlines
+* text=auto eol=lf


### PR DESCRIPTION
Without this, on Windows with `autocrlf` which is the default, we end up with modified files just for their line endings.