### PR TITLE
Single comment with quote

### DIFF
--- a/lib/nodes/inline-comment.js
+++ b/lib/nodes/inline-comment.js
@@ -9,6 +9,7 @@ module.exports = {
       const first = token;
       const bits = [];
       let last;
+      let remainingInput;
 
       while (token) {
         if (/\r?\n/.test(token[1])) {
@@ -18,12 +19,8 @@ module.exports = {
             bits.push(token[1].substring(0, token[1].indexOf('\n')));
 
             // Get remaining input and retokenize
-            let remainingInput = token[1].substring(token[1].indexOf('\n'));
+            remainingInput = token[1].substring(token[1].indexOf('\n'));
             remainingInput += this.input.css.valueOf().substring(this.tokenizer.position());
-
-            // Replace tokenizer to retokenize the rest of the string
-            this.input = new Input(remainingInput);
-            this.tokenizer = tokenizer(this.input);
           } else {
             // If the tokenizer went to the next line go back
             this.tokenizer.back(token);
@@ -37,8 +34,15 @@ module.exports = {
       }
 
       const newToken = ['comment', bits.join(''), first[2], first[3], last[2], last[3]];
-
       this.inlineComment(newToken);
+
+      // Replace tokenizer to retokenize the rest of the string
+      // we need replace it after we added new token with inline comment because token position is calculated for old input (#145)
+      if (remainingInput) {
+        this.input = new Input(remainingInput);
+        this.tokenizer = tokenizer(this.input);
+      }
+
       return true;
     } else if (token[1] === '/') {
       // issue #135

--- a/test/parser/comments.test.js
+++ b/test/parser/comments.test.js
@@ -98,6 +98,19 @@ test('two subsequent inline comments with unmatched quotes', (t) => {
   t.is(nodeToString(root), less);
 });
 
+test('inline comments with quotes and new line(#145)', (t) => {
+  const less = `
+      // batman'
+  `;
+
+  const root = parse(less);
+  const { first } = root;
+
+  t.is(first.type, 'comment');
+  t.is(first.text, `batman'`);
+  t.is(nodeToString(root), less);
+});
+
 test('close empty', (t) => {
   const less = '// \n//';
   const root = parse(less);


### PR DESCRIPTION
**Which issue #145 if any, does this resolve?

<!-- PRs must be accompanied by related tests -->

Please check one:
- [x] New tests created for this change
- [ ] Tests updated for this change

This PR:
- [ ] Adds new API
- [ ] Extends existing API, backwards-compatible
- [ ] Introduces a breaking change
- [x] Fixes a bug

---

<!-- add additional comments here -->
This fix is simple. Before when code finds a quote symbol in comment it overwrites an `this.input` and `this.tokenizer` before new token for the comment is created. It means when code tries to get a position by offset `getPosition` it searches for in in new input, but should in old one. 
