### PR TITLE
fix parse interpolation error

### DIFF
--- a/lib/nodes/interpolation.js
+++ b/lib/nodes/interpolation.js
@@ -2,25 +2,23 @@
 
 module.exports = {
   interpolation(token) {
-    let first = token;
-    const tokens = [token];
-    const validTypes = ['word', '{', '}'];
-
-    token = this.tokenizer.nextToken();
+    const tokens = [token, this.tokenizer.nextToken()];
+    const validTypes = ['word', '}'];
 
     // look for @{ but not @[word]{
-    if (first[1].length > 1 || token[0] !== '{') {
-      this.tokenizer.back(token);
+    if (tokens[0][1].length > 1 || tokens[1][0] !== '{') {
+      this.tokenizer.back(tokens[1]);
       return false;
     }
 
+    token = this.tokenizer.nextToken();
     while (token && validTypes.includes(token[0])) {
       tokens.push(token);
       token = this.tokenizer.nextToken();
     }
 
     const words = tokens.map((tokn) => tokn[1]);
-    [first] = tokens;
+    const [first] = tokens;
     const last = tokens.pop();
     const start = [first[2], first[3]];
     const end = [last[4] || last[2], last[5] || last[3]];

--- a/test/parser/interpolation.test.js
+++ b/test/parser/interpolation.test.js
@@ -12,6 +12,14 @@ test('parses interpolation', (t) => {
   t.is(root.first.first.value, '@{color}');
 });
 
+test('parses interpolation when there is not space between selector with open bracket', (t) => {
+  const root = parse('@{selector}-title{ @{prop}-size: @{color} }');
+
+  t.is(root.first.selector, '@{selector}-title');
+  t.is(root.first.first.prop, '@{prop}-size');
+  t.is(root.first.first.value, '@{color}');
+});
+
 test('parses mixin interpolation', (t) => {
   const less = '.browser-prefix(@prop, @args) {\n @{prop}: @args;\n}';
   const root = parse(less);


### PR DESCRIPTION
hello, when i use postcss-less as less preprocessor parser in my project, i get some parse error.
here is my example:
`@{prefix}-title{\ncolor: red;}`;

i try debug internal code, i found that when parse interpolation, token match would not stop util not match `@|{|}`, in my example, the final match token is `@{prefix}-title{`，i guess this works unexpected，so i try to fix it. make the `{` token just match once, in my project, it works fine.

Please check one:
- [x] New tests created for this change

This PR:
- [ ] Adds new API
- [ ] Extends existing API, backwards-compatible
- [ ] Introduces a breaking change
- [x] Fixes a bug
