### PR TITLE
fix: source map generation (following #150)

### DIFF
--- a/lib/LessParser.js
+++ b/lib/LessParser.js
@@ -67,9 +67,8 @@ module.exports = class LessParser extends Parser {
     const node = new Comment();
     const text = token[1].slice(2);
 
-    this.init(node, token[2], token[3]);
-
-    node.source.end = { line: token[4], column: token[5] };
+    this.init(node, token[2]);
+    node.source.end = this.getPosition(token[3] || token[2]);
     node.inline = true;
     node.raws.begin = '//';
 

--- a/lib/nodes/inline-comment.js
+++ b/lib/nodes/inline-comment.js
@@ -33,7 +33,7 @@ module.exports = {
         token = this.tokenizer.nextToken({ ignoreUnclosed: true });
       }
 
-      const newToken = ['comment', bits.join(''), first[2], first[3], last[2], last[3]];
+      const newToken = ['comment', bits.join(''), first[2], last[2]];
       this.inlineComment(newToken);
 
       // Replace tokenizer to retokenize the rest of the string

--- a/lib/nodes/interpolation.js
+++ b/lib/nodes/interpolation.js
@@ -22,9 +22,7 @@ module.exports = {
     const words = tokens.map((tokn) => tokn[1]);
     [first] = tokens;
     const last = tokens.pop();
-    const start = [first[2], first[3]];
-    const end = [last[4] || last[2], last[5] || last[3]];
-    const newToken = ['word', words.join('')].concat(start, end);
+    const newToken = ['word', words.join(''), first[2], last[2]];
 
     this.tokenizer.back(token);
     this.tokenizer.back(newToken);

--- a/test/map.test.js
+++ b/test/map.test.js
@@ -1,0 +1,47 @@
+const test = require("ava");
+const postcss = require("postcss");
+const { readFileSync } = require("fs");
+const { join } = require("path");
+
+const syntax = require("../lib");
+
+const { parser } = syntax;
+
+// silence the rediculously verbose "You did not set any plugins, parser, or
+// stringifier" warnings in PostCSS.
+console.warn = () => {}; // eslint-disable-line no-console
+
+test("should parse LESS integration syntax and generate a source map", async t => {
+  const less = readFileSync(
+    join(__dirname, "./integration/ext.cx.dashboard.less"),
+    "utf-8"
+  );
+  const result = await postcss().process(less, {
+    syntax,
+    parser,
+    map: { inline: false, annotation: false, sourcesContent: true }
+  });
+
+  t.truthy(result);
+  t.is(result.css, less);
+  t.is(result.content, less);
+  t.truthy(result.map);
+});
+
+test("should parse LESS inline comment syntax and generate a source map", async t => {
+  const less = `
+  a {
+    //background-color: red;
+  }
+  `;
+  const result = await postcss().process(less, {
+    syntax,
+    parser,
+    map: { inline: false, annotation: false, sourcesContent: true }
+  });
+
+  t.truthy(result);
+  t.is(result.css, less);
+  t.is(result.content, less);
+  t.truthy(result.map);
+});


### PR DESCRIPTION
**Which issue #** 

Sourcemap generation when used with postcss-less doesnt work (probably since the update to postcss 8).

Issues is related to AST locations. It translates into silent errors (wrong source mapping) in most cases, except when used to transpile inline comments ending with a ";" (as seen in the added test). In that last case transpilation throws an error.

Please check one:
- [x] New tests created for this change
- [ ] Tests updated for this change

This PR:
- [ ] Adds new API
- [ ] Extends existing API, backwards-compatible
- [ ] Introduces a breaking change
- [x] Fixes a bug
