### PR TITLE
Fix node positional information for files with single-quotes in comments

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,6 +12,46 @@ module.exports = {
 
     parser.parse();
 
+    parser.root.walk((node, index) => {
+      // TODO: post-process here
+      console.log('=========');
+      const offset = input.css.lastIndexOf(node.source.input.css);
+      console.log('computed offset:', offset);
+      console.log('input.css:', input.css);
+      console.log('node.source.input.css:', node.source.input.css);
+      console.log('original source:', node.source);
+
+      // Sanity check
+      if (offset + node.source.input.css.length !== input.css.length) {
+        console.log('input.css:', input.css);
+        console.log('node.source.input.css:', node.source.input.css);
+        throw new Error('TODO handle me');
+      }
+
+      const newStartOffset = offset + node.source.start.offset;
+      const newEndOffset = offset + node.source.end.offset;
+      const newStartPosition = input.fromOffset(offset + node.source.start.offset);
+      const newEndPosition = input.fromOffset(offset + node.source.end.offset);
+
+      // eslint-disable-next-line no-param-reassign
+      node.source.start = {
+        offset: newStartOffset,
+        line: newStartPosition.line,
+        column: newStartPosition.col
+      };
+
+      // eslint-disable-next-line no-param-reassign
+      node.source.end = {
+        offset: newEndOffset,
+        line: newEndPosition.line,
+        column: newEndPosition.col
+      }
+
+      console.log(node.source.start);
+      node.source.end = input.fromOffset(offset + node.source.end.offset);
+      console.log(node.source.end);
+    });
+
     return parser.root;
   },
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,26 +12,30 @@ module.exports = {
 
     parser.parse();
 
-    parser.root.walk((node, index) => {
-      // TODO: post-process here
-      console.log('=========');
+    // To handle double-slash comments (`//`) we end up creating a new tokenizer
+    // in certain cases (see `lib/nodes/inline-comment.js`). However, this means
+    // that any following node in the AST will have incorrect start/end positions
+    // on the `source` property. To fix that, we'll walk the AST and compute
+    // updated positions for all nodes.
+    parser.root.walk((node) => {
       const offset = input.css.lastIndexOf(node.source.input.css);
-      console.log('computed offset:', offset);
-      console.log('input.css:', input.css);
-      console.log('node.source.input.css:', node.source.input.css);
-      console.log('original source:', node.source);
 
-      // Sanity check
+      if (offset === 0) {
+        // Short circuit - this node was processed with the original tokenizer
+        // and should therefore have correct position information.
+        return;
+      }
+
+      // This ensures that the chunk of source we're processing corresponds
+      // strictly to a terminal substring of the input CSS. This should always
+      // be the case, but if it ever isn't, we prefer to fail instead of
+      // producing potentially invalid output.
       if (offset + node.source.input.css.length !== input.css.length) {
-        console.log('input.css:', input.css);
-        console.log('node.source.input.css:', node.source.input.css);
-        throw new Error('TODO handle me');
+        throw new Error('Invalid state detected in postcss-less');
       }
 
       const newStartOffset = offset + node.source.start.offset;
-      const newEndOffset = offset + node.source.end.offset;
       const newStartPosition = input.fromOffset(offset + node.source.start.offset);
-      const newEndPosition = input.fromOffset(offset + node.source.end.offset);
 
       // eslint-disable-next-line no-param-reassign
       node.source.start = {
@@ -40,16 +44,18 @@ module.exports = {
         column: newStartPosition.col
       };
 
-      // eslint-disable-next-line no-param-reassign
-      node.source.end = {
-        offset: newEndOffset,
-        line: newEndPosition.line,
-        column: newEndPosition.col
-      }
+      // Not all nodes have an `end` property.
+      if (node.source.end) {
+        const newEndOffset = offset + node.source.end.offset;
+        const newEndPosition = input.fromOffset(offset + node.source.end.offset);
 
-      console.log(node.source.start);
-      node.source.end = input.fromOffset(offset + node.source.end.offset);
-      console.log(node.source.end);
+        // eslint-disable-next-line no-param-reassign
+        node.source.end = {
+          offset: newEndOffset,
+          line: newEndPosition.line,
+          column: newEndPosition.col
+        };
+      }
     });
 
     return parser.root;

--- a/lib/index.js
+++ b/lib/index.js
@@ -30,6 +30,7 @@ module.exports = {
       // strictly to a terminal substring of the input CSS. This should always
       // be the case, but if it ever isn't, we prefer to fail instead of
       // producing potentially invalid output.
+      // istanbul ignore next
       if (offset + node.source.input.css.length !== input.css.length) {
         throw new Error('Invalid state detected in postcss-less');
       }

--- a/lib/nodes/inline-comment.js
+++ b/lib/nodes/inline-comment.js
@@ -8,7 +8,7 @@ module.exports = {
     if (token[0] === 'word' && token[1].slice(0, 2) === '//') {
       const first = token;
       const bits = [];
-      let last;
+      let endOffset;
       let remainingInput;
 
       while (token) {
@@ -20,7 +20,12 @@ module.exports = {
 
             // Get remaining input and retokenize
             remainingInput = token[1].substring(token[1].indexOf('\n'));
-            remainingInput += this.input.css.valueOf().substring(this.tokenizer.position());
+            const untokenizedRemainingInput = this.input.css
+              .valueOf()
+              .substring(this.tokenizer.position());
+            remainingInput += untokenizedRemainingInput;
+
+            endOffset = token[3] + untokenizedRemainingInput.length - remainingInput.length;
           } else {
             // If the tokenizer went to the next line go back
             this.tokenizer.back(token);
@@ -29,11 +34,12 @@ module.exports = {
         }
 
         bits.push(token[1]);
-        last = token;
+        // eslint-disable-next-line prefer-destructuring
+        endOffset = token[2];
         token = this.tokenizer.nextToken({ ignoreUnclosed: true });
       }
 
-      const newToken = ['comment', bits.join(''), first[2], last[2]];
+      const newToken = ['comment', bits.join(''), first[2], endOffset];
       this.inlineComment(newToken);
 
       // Replace tokenizer to retokenize the rest of the string

--- a/test/parser/comments.test.js
+++ b/test/parser/comments.test.js
@@ -179,3 +179,20 @@ test('inline comments with asterisk are persisted (#135)', (t) => {
   t.is(first.text, '*batman');
   t.is(nodeToString(root), less);
 });
+
+test.only('handles single quotes in comments', (t) => {
+  const less = `.a {\n  // '\n  outline-width: 0 !important;\n}\n\n/** ' */`;
+
+  const root = parse(less);
+  const { first } = root;
+
+  const [commentNode, declarationNode] = first.nodes;
+
+  t.is(commentNode.type, 'comment');
+
+  t.is(declarationNode.type, 'decl');
+  t.is(declarationNode.source.start.line, 3);
+  t.is(declarationNode.source.start.column, 3);
+  t.is(declarationNode.source.end.line, 3);
+  t.is(declarationNode.source.end.column, 30);
+});

--- a/test/parser/comments.test.js
+++ b/test/parser/comments.test.js
@@ -180,7 +180,7 @@ test('inline comments with asterisk are persisted (#135)', (t) => {
   t.is(nodeToString(root), less);
 });
 
-test('handles single quotes in comments (#163)', (t) => {
+test.only('handles single quotes in comments (#163)', (t) => {
   const less = `a {\n  // '\n  color: pink;\n}\n\n/** ' */`;
 
   const root = parse(less);
@@ -190,10 +190,21 @@ test('handles single quotes in comments (#163)', (t) => {
   t.is(ruleNode.type, 'rule');
   t.is(commentNode.type, 'comment');
 
+  t.is(commentNode.source.start.line, 6);
+  t.is(commentNode.source.start.column, 1);
+  t.is(commentNode.source.end.line, 6);
+  t.is(commentNode.source.end.column, 8);
+
   const [innerCommentNode, declarationNode] = ruleNode.nodes;
 
   t.is(innerCommentNode.type, 'comment');
   t.is(declarationNode.type, 'decl');
+
+  t.is(innerCommentNode.source.start.line, 2);
+  t.is(innerCommentNode.source.start.column, 3);
+  t.is(innerCommentNode.source.end.line, 2);
+  // TODO: this test is failing
+  // t.is(innerCommentNode.source.end.column, 6);
 
   t.is(declarationNode.source.start.line, 3);
   t.is(declarationNode.source.start.column, 3);

--- a/test/parser/comments.test.js
+++ b/test/parser/comments.test.js
@@ -180,21 +180,25 @@ test('inline comments with asterisk are persisted (#135)', (t) => {
   t.is(nodeToString(root), less);
 });
 
-test('handles single quotes in comments', (t) => {
-  const less = `.a {\n  // '\n  outline-width: 0 !important;\n}\n\n/** ' */`;
+test.only('handles single quotes in comments', (t) => {
+  const less = `a {\n  // '\n  color: pink;\n}\n\n/** ' */`;
 
   const root = parse(less);
-  const { first } = root;
 
-  const [commentNode, declarationNode] = first.nodes;
+  const [ruleNode, commentNode] = root.nodes;
 
+  t.is(ruleNode.type, 'rule');
   t.is(commentNode.type, 'comment');
 
+  const [innerCommentNode, declarationNode] = ruleNode.nodes;
+
+  t.is(innerCommentNode.type, 'comment');
   t.is(declarationNode.type, 'decl');
+
   t.is(declarationNode.source.start.line, 3);
   t.is(declarationNode.source.start.column, 3);
   t.is(declarationNode.source.end.line, 3);
-  t.is(declarationNode.source.end.column, 30);
+  t.is(declarationNode.source.end.column, 14);
 
   t.is(nodeToString(root), less);
 });

--- a/test/parser/comments.test.js
+++ b/test/parser/comments.test.js
@@ -180,7 +180,7 @@ test('inline comments with asterisk are persisted (#135)', (t) => {
   t.is(nodeToString(root), less);
 });
 
-test.only('handles single quotes in comments', (t) => {
+test('handles single quotes in comments (#163)', (t) => {
   const less = `a {\n  // '\n  color: pink;\n}\n\n/** ' */`;
 
   const root = parse(less);

--- a/test/parser/comments.test.js
+++ b/test/parser/comments.test.js
@@ -180,7 +180,7 @@ test('inline comments with asterisk are persisted (#135)', (t) => {
   t.is(nodeToString(root), less);
 });
 
-test.only('handles single quotes in comments', (t) => {
+test('handles single quotes in comments', (t) => {
   const less = `.a {\n  // '\n  outline-width: 0 !important;\n}\n\n/** ' */`;
 
   const root = parse(less);

--- a/test/parser/comments.test.js
+++ b/test/parser/comments.test.js
@@ -180,7 +180,7 @@ test('inline comments with asterisk are persisted (#135)', (t) => {
   t.is(nodeToString(root), less);
 });
 
-test.only('handles single quotes in comments (#163)', (t) => {
+test('handles single quotes in comments (#163)', (t) => {
   const less = `a {\n  // '\n  color: pink;\n}\n\n/** ' */`;
 
   const root = parse(less);
@@ -203,8 +203,7 @@ test.only('handles single quotes in comments (#163)', (t) => {
   t.is(innerCommentNode.source.start.line, 2);
   t.is(innerCommentNode.source.start.column, 3);
   t.is(innerCommentNode.source.end.line, 2);
-  // TODO: this test is failing
-  // t.is(innerCommentNode.source.end.column, 6);
+  t.is(innerCommentNode.source.end.column, 6);
 
   t.is(declarationNode.source.start.line, 3);
   t.is(declarationNode.source.start.column, 3);

--- a/test/parser/comments.test.js
+++ b/test/parser/comments.test.js
@@ -195,4 +195,6 @@ test.only('handles single quotes in comments', (t) => {
   t.is(declarationNode.source.start.column, 3);
   t.is(declarationNode.source.end.line, 3);
   t.is(declarationNode.source.end.column, 30);
+
+  t.is(nodeToString(root), less);
 });


### PR DESCRIPTION
This resolves issue #163.

Please check one:
- [x] New tests created for this change
- [ ] Tests updated for this change

This PR:
- [ ] Adds new API
- [ ] Extends existing API, backwards-compatible
- [ ] Introduces a breaking change
- [x] Fixes a bug

---

This PR is my attempt at resolving the issue described in #163. It makes the new tests I added pass, and it doesn't break any existing tests. Unfortunately, most of the existing tests don't assert anything about positional information, so it's pretty difficult for me to assert that this doesn't adversely impact anything else. I'd be happy to augment some existing tests with positional information to help increase confidence.

The change to `lib/nodes/inline-comment.js` was necessary to get the following assertion about the end position of a comment to pass:

```js
t.is(innerCommentNode.source.end.column, 6);
```